### PR TITLE
style: apply CSS variables for dark theme

### DIFF
--- a/app/ExpenseForm.module.css
+++ b/app/ExpenseForm.module.css
@@ -6,7 +6,9 @@
   padding: 8px;
   margin: 5px;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--accent);
+  background: color-mix(in srgb, var(--bg), var(--fg) 5%);
+  color: var(--fg);
 }
 
 .button {
@@ -14,10 +16,10 @@
   margin: 5px;
   border-radius: 4px;
   border: none;
-  background: #0d6efd;
-  color: #fff;
+  background: var(--accent);
+  color: var(--fg);
 }
 
 .button:hover {
-  background: #0b5ed7;
+  background: color-mix(in srgb, var(--accent), black 10%);
 }

--- a/app/ExpenseTable.module.css
+++ b/app/ExpenseTable.module.css
@@ -2,21 +2,22 @@
   width: 100%;
   border-collapse: collapse;
   margin-top: 15px;
-  background: #fff;
+  background: color-mix(in srgb, var(--bg), var(--fg) 5%);
+  color: var(--fg);
 }
 
 .th, .td {
   padding: 10px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid color-mix(in srgb, var(--bg), var(--fg) 20%);
   text-align: left;
 }
 
 .th {
-  background: #e9ecef;
+  background: color-mix(in srgb, var(--bg), var(--fg) 10%);
 }
 
 .removeBtn {
-  color: #dc3545;
+  color: var(--accent);
   background: none;
   border: none;
   cursor: pointer;

--- a/app/TotalDisplay.module.css
+++ b/app/TotalDisplay.module.css
@@ -1,10 +1,12 @@
 .tfoot td {
   font-weight: bold;
-  background: #f1f3f5;
+  background: color-mix(in srgb, var(--bg), var(--fg) 10%);
+  color: var(--fg);
 }
 
 .td {
   padding: 10px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid color-mix(in srgb, var(--bg), var(--fg) 20%);
   text-align: left;
+  color: var(--fg);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,16 @@
+:root {
+  --bg: #121212;
+  --fg: #e0e0e0;
+  --accent: #2563eb;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 40px;
-  background: #f5f6fa;
+  background: var(--bg);
+  color: var(--fg);
 }
 
 h2 {
-  color: #333;
+  color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- define reusable color variables in globals.css for dark theme
- switch expense form, table, and totals modules to use color variables
- improve heading, table, and total displays with high-contrast text and backgrounds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a44ade6b1c8320b9778f72e1432292