### PR TITLE
feat: add expense category

### DIFF
--- a/app/ExpenseForm.js
+++ b/app/ExpenseForm.js
@@ -7,6 +7,7 @@ export default function ExpenseForm({ onAdd }) {
   const [date, setDate] = useState('');
   const [desc, setDesc] = useState('');
   const [amount, setAmount] = useState('');
+  const [category, setCategory] = useState('');
 
   useEffect(() => {
     const today = new Date().toISOString().split('T')[0];
@@ -15,9 +16,10 @@ export default function ExpenseForm({ onAdd }) {
 
   const handleSubmit = e => {
     e.preventDefault();
-    onAdd({ date, desc: desc.trim(), amount });
+    onAdd({ date, desc: desc.trim(), amount, category: category.trim() });
     setDesc('');
     setAmount('');
+    setCategory('');
   };
 
   return (
@@ -35,6 +37,14 @@ export default function ExpenseForm({ onAdd }) {
         placeholder="Description"
         value={desc}
         onChange={e => setDesc(e.target.value)}
+        required
+      />
+      <input
+        type="text"
+        className={styles.input}
+        placeholder="Category"
+        value={category}
+        onChange={e => setCategory(e.target.value)}
         required
       />
       <input

--- a/app/ExpenseTable.js
+++ b/app/ExpenseTable.js
@@ -1,34 +1,48 @@
 'use client';
 
+import { useState } from 'react';
 import TotalDisplay from './TotalDisplay';
 import styles from './ExpenseTable.module.css';
 
 export default function ExpenseTable({ expenses, onRemove }) {
-  const total = expenses.reduce((sum, exp) => sum + parseFloat(exp.amount || 0), 0);
+  const [filter, setFilter] = useState('');
+  const categories = Array.from(new Set(expenses.map(e => e.category)));
+  const filtered = filter ? expenses.filter(e => e.category === filter) : expenses;
+  const total = filtered.reduce((sum, exp) => sum + parseFloat(exp.amount || 0), 0);
 
   return (
-    <table className={styles.table}>
-      <thead>
-        <tr>
-          <th className={styles.th}>Date</th>
-          <th className={styles.th}>Description</th>
-          <th className={styles.th}>Amount ($)</th>
-          <th className={styles.th}>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {expenses.map((exp, idx) => (
-          <tr key={idx}>
-            <td className={styles.td}>{exp.date}</td>
-            <td className={styles.td}>{exp.desc}</td>
-            <td className={styles.td}>${parseFloat(exp.amount).toFixed(2)}</td>
-            <td className={styles.td}>
-              <button className={styles.removeBtn} onClick={() => onRemove(idx)}>Remove</button>
-            </td>
-          </tr>
+    <>
+      <select className={styles.select} value={filter} onChange={e => setFilter(e.target.value)}>
+        <option value="">All Categories</option>
+        {categories.map(cat => (
+          <option key={cat} value={cat}>{cat}</option>
         ))}
-      </tbody>
-      <TotalDisplay total={total} />
-    </table>
+      </select>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={styles.th}>Date</th>
+            <th className={styles.th}>Description</th>
+            <th className={styles.th}>Category</th>
+            <th className={styles.th}>Amount ($)</th>
+            <th className={styles.th}>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((exp, idx) => (
+            <tr key={idx}>
+              <td className={styles.td}>{exp.date}</td>
+              <td className={styles.td}>{exp.desc}</td>
+              <td className={styles.td}>{exp.category}</td>
+              <td className={styles.td}>${parseFloat(exp.amount).toFixed(2)}</td>
+              <td className={styles.td}>
+                <button className={styles.removeBtn} onClick={() => onRemove(idx)}>Remove</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <TotalDisplay total={total} />
+      </table>
+    </>
   );
 }

--- a/app/ExpenseTable.module.css
+++ b/app/ExpenseTable.module.css
@@ -21,3 +21,8 @@
   border: none;
   cursor: pointer;
 }
+
+.select {
+  margin-bottom: 10px;
+  padding: 5px;
+}

--- a/app/page.js
+++ b/app/page.js
@@ -28,9 +28,11 @@ function ExpenseDashboard() {
   const [form, setForm] = useState({
     date: new Date().toISOString().substr(0, 10),
     description: '',
-    amount: ''
+    amount: '',
+    category: ''
   });
   const [editingId, setEditingId] = useState(null);
+  const [categoryFilter, setCategoryFilter] = useState('');
 
   useEffect(() => {
     async function loadExpenses() {
@@ -69,7 +71,7 @@ function ExpenseDashboard() {
       } else {
         setExpenses((prev) => [saved, ...prev]);
       }
-      setForm({ date: new Date().toISOString().substr(0, 10), description: '', amount: '' });
+      setForm({ date: new Date().toISOString().substr(0, 10), description: '', amount: '', category: '' });
       setEditingId(null);
     } catch (err) {
       setError(err.message);
@@ -92,6 +94,7 @@ function ExpenseDashboard() {
       date: new Date(exp.date).toISOString().substr(0, 10),
       description: exp.description,
       amount: exp.amount.toString(),
+      category: exp.category,
     });
     setEditingId(exp.id);
   };
@@ -99,7 +102,9 @@ function ExpenseDashboard() {
   if (loading) return <p>Loading...</p>;
   if (error) return <p role="alert">Error: {error}</p>;
 
-  const total = expenses.reduce((sum, exp) => sum + exp.amount, 0);
+  const categories = Array.from(new Set(expenses.map(e => e.category)));
+  const displayed = categoryFilter ? expenses.filter(exp => exp.category === categoryFilter) : expenses;
+  const total = displayed.reduce((sum, exp) => sum + exp.amount, 0);
 
   return (
     <div className="container">
@@ -107,26 +112,35 @@ function ExpenseDashboard() {
       <form id="expense-form" onSubmit={handleSubmit}>
         <input type="date" id="date" value={form.date} onChange={handleChange} required />
         <input type="text" id="description" value={form.description} onChange={handleChange} placeholder="Description" required />
+        <input type="text" id="category" value={form.category} onChange={handleChange} placeholder="Category" required />
         <input type="number" id="amount" value={form.amount} onChange={handleChange} placeholder="Amount" min="0.01" step="0.01" required />
         <button type="submit">{editingId ? 'Update' : 'Add'} Expense</button>
         {editingId && (
-          <button type="button" onClick={() => { setEditingId(null); setForm({ date: new Date().toISOString().substr(0, 10), description: '', amount: '' }); }}>Cancel</button>
+          <button type="button" onClick={() => { setEditingId(null); setForm({ date: new Date().toISOString().substr(0, 10), description: '', amount: '', category: '' }); }}>Cancel</button>
         )}
       </form>
+      <select value={categoryFilter} onChange={e => setCategoryFilter(e.target.value)}>
+        <option value="">All Categories</option>
+        {categories.map(cat => (
+          <option key={cat} value={cat}>{cat}</option>
+        ))}
+      </select>
       <table id="expense-table">
         <thead>
           <tr>
             <th>Date</th>
             <th>Description</th>
+            <th>Category</th>
             <th>Amount ($)</th>
             <th>Actions</th>
           </tr>
         </thead>
         <tbody>
-          {expenses.map((exp) => (
+          {displayed.map((exp) => (
             <tr key={exp.id}>
               <td>{new Date(exp.date).toLocaleDateString()}</td>
               <td>{exp.description}</td>
+              <td>{exp.category}</td>
               <td>${exp.amount.toFixed(2)}</td>
               <td>
                 <button onClick={() => editExpense(exp)}>Edit</button>
@@ -137,7 +151,7 @@ function ExpenseDashboard() {
         </tbody>
         <tfoot>
           <tr>
-            <td colSpan="2">Total</td>
+            <td colSpan="3">Total</td>
             <td id="total">${total.toFixed(2)}</td>
             <td></td>
           </tr>

--- a/pages/api/expenses.js
+++ b/pages/api/expenses.js
@@ -6,7 +6,11 @@ export default async function handler(req, res) {
   switch (method) {
     case 'GET':
       try {
-        const expenses = await prisma.expense.findMany({ orderBy: { date: 'desc' } });
+        const { category } = req.query;
+        const expenses = await prisma.expense.findMany({
+          where: category ? { category } : undefined,
+          orderBy: { date: 'desc' },
+        });
         res.status(200).json(expenses);
       } catch (error) {
         res.status(500).json({ error: 'Failed to load expenses' });
@@ -14,12 +18,13 @@ export default async function handler(req, res) {
       break;
     case 'POST':
       try {
-        const { date, description, amount } = req.body;
+        const { date, description, amount, category } = req.body;
         const expense = await prisma.expense.create({
           data: {
             date: new Date(date),
             description,
             amount: parseFloat(amount),
+            category,
           },
         });
         res.status(201).json(expense);
@@ -29,13 +34,14 @@ export default async function handler(req, res) {
       break;
     case 'PUT':
       try {
-        const { id, date, description, amount } = req.body;
+        const { id, date, description, amount, category } = req.body;
         const expense = await prisma.expense.update({
           where: { id: parseInt(id, 10) },
           data: {
             date: new Date(date),
             description,
             amount: parseFloat(amount),
+            category,
           },
         });
         res.status(200).json(expense);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,4 +14,5 @@ model Expense {
   date        DateTime
   description String
   amount      Float
+  category    String
 }


### PR DESCRIPTION
## Summary
- track expense categories in Prisma schema and API
- add category input and filtering in expense components
- allow dashboard to filter expenses by category

## Testing
- `npx prisma generate`
- `npx prisma db push`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a44ae4b3008320b18ebd16f225b5b2