### PR TITLE
Enable expense categories and dark theme styles

### DIFF
--- a/app/ExpenseChart.js
+++ b/app/ExpenseChart.js
@@ -8,17 +8,21 @@ import {
   Tooltip,
   CartesianGrid,
   ResponsiveContainer,
+  Legend,
 } from 'recharts';
 
 export default function ExpenseChart({ expenses }) {
+  const categories = Array.from(new Set(expenses.map(e => e.category)));
   const data = Object.values(
     expenses.reduce((acc, exp) => {
       const date = new Date(exp.date).toLocaleDateString();
-      if (!acc[date]) acc[date] = { date, amount: 0 };
-      acc[date].amount += exp.amount;
+      if (!acc[date]) acc[date] = { date };
+      acc[date][exp.category] = (acc[date][exp.category] || 0) + exp.amount;
       return acc;
     }, {})
   );
+
+  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 
   return (
     <div style={{ width: '100%', height: 300 }}>
@@ -28,7 +32,10 @@ export default function ExpenseChart({ expenses }) {
           <XAxis dataKey="date" />
           <YAxis />
           <Tooltip />
-          <Bar dataKey="amount" fill="#8884d8" />
+          <Legend />
+          {categories.map((cat, idx) => (
+            <Bar key={cat} dataKey={cat} stackId="a" fill={colors[idx % colors.length]} />
+          ))}
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/app/TotalDisplay.js
+++ b/app/TotalDisplay.js
@@ -6,7 +6,7 @@ export default function TotalDisplay({ total }) {
   return (
     <tfoot className={styles.tfoot}>
       <tr>
-        <td className={styles.td} colSpan="2">Total</td>
+        <td className={styles.td} colSpan="3">Total</td>
         <td className={styles.td}>${total.toFixed(2)}</td>
         <td className={styles.td}></td>
       </tr>

--- a/app/page.js
+++ b/app/page.js
@@ -3,10 +3,11 @@
 import React, { useState, useEffect } from 'react';
 import ExpenseChart from './ExpenseChart';
 function expensesToCSV(expenses) {
-  const header = ['Date', 'Description', 'Amount'];
+  const header = ['Date', 'Description', 'Category', 'Amount'];
   const rows = expenses.map((exp) => [
     new Date(exp.date).toISOString().split('T')[0],
     `"${exp.description.replace(/"/g, '""')}"`,
+    `"${(exp.category || '').replace(/"/g, '""')}"`,
     exp.amount.toFixed(2),
   ]);
   return [header, ...rows].map((row) => row.join(',')).join('\n');
@@ -186,10 +187,11 @@ function ExpenseDashboard() {
         .container {
           font-family: Arial, sans-serif;
           margin: 40px;
-          background: #f5f6fa;
+          background: var(--bg);
+          color: var(--fg);
         }
         h2 {
-          color: #333;
+          color: var(--accent);
         }
         #expense-form {
           margin-bottom: 20px;
@@ -198,36 +200,39 @@ function ExpenseDashboard() {
           padding: 8px;
           margin: 5px;
           border-radius: 4px;
-          border: 1px solid #ccc;
+          border: 1px solid var(--accent);
+          background: color-mix(in srgb, var(--bg), var(--fg) 5%);
+          color: var(--fg);
         }
         button {
-          background: #0d6efd;
-          color: #fff;
+          background: var(--accent);
+          color: var(--fg);
           border: none;
         }
         button:hover {
-          background: #0b5ed7;
+          background: color-mix(in srgb, var(--accent), black 10%);
         }
         table {
           width: 100%;
           border-collapse: collapse;
           margin-top: 15px;
-          background: #fff;
+          background: color-mix(in srgb, var(--bg), var(--fg) 5%);
+          color: var(--fg);
         }
         th, td {
           padding: 10px;
-          border-bottom: 1px solid #eee;
+          border-bottom: 1px solid color-mix(in srgb, var(--bg), var(--fg) 20%);
           text-align: left;
         }
         th {
-          background: #e9ecef;
+          background: color-mix(in srgb, var(--bg), var(--fg) 10%);
         }
         tfoot td {
           font-weight: bold;
-          background: #f1f3f5;
+          background: color-mix(in srgb, var(--bg), var(--fg) 10%);
         }
         .remove-btn {
-          color: #dc3545;
+          color: var(--accent);
           background: none;
           border: none;
           cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -4,13 +4,19 @@
   <meta charset="UTF-8">
   <title>Daily Expense Dashboard</title>
   <style>
+    :root {
+      --bg: #121212;
+      --fg: #e0e0e0;
+      --accent: #2563eb;
+    }
     body {
       font-family: Arial, sans-serif;
       margin: 40px;
-      background: #f5f6fa;
+      background: var(--bg);
+      color: var(--fg);
     }
     h2 {
-      color: #333;
+      color: var(--accent);
     }
     #expense-form {
       margin-bottom: 20px;
@@ -19,36 +25,39 @@
       padding: 8px;
       margin: 5px;
       border-radius: 4px;
-      border: 1px solid #ccc;
+      border: 1px solid var(--accent);
+      background: color-mix(in srgb, var(--bg), var(--fg) 5%);
+      color: var(--fg);
     }
     button {
-      background: #0d6efd;
-      color: #fff;
+      background: var(--accent);
+      color: var(--fg);
       border: none;
     }
     button:hover {
-      background: #0b5ed7;
+      background: color-mix(in srgb, var(--accent), black 10%);
     }
     table {
       width: 100%;
       border-collapse: collapse;
       margin-top: 15px;
-      background: #fff;
+      background: color-mix(in srgb, var(--bg), var(--fg) 5%);
+      color: var(--fg);
     }
     th, td {
       padding: 10px;
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid color-mix(in srgb, var(--bg), var(--fg) 20%);
       text-align: left;
     }
     th {
-      background: #e9ecef;
+      background: color-mix(in srgb, var(--bg), var(--fg) 10%);
     }
     tfoot td {
       font-weight: bold;
-      background: #f1f3f5;
+      background: color-mix(in srgb, var(--bg), var(--fg) 10%);
     }
     .remove-btn {
-      color: #dc3545;
+      color: var(--accent);
       background: none;
       border: none;
       cursor: pointer;
@@ -60,6 +69,7 @@
   <form id="expense-form">
     <input type="date" id="date" required>
     <input type="text" id="description" placeholder="Description" required>
+    <input type="text" id="category" placeholder="Category" required>
     <input type="number" id="amount" placeholder="Amount" min="0.01" step="0.01" required>
     <button type="submit">Add Expense</button>
   </form>
@@ -68,6 +78,7 @@
       <tr>
         <th>Date</th>
         <th>Description</th>
+        <th>Category</th>
         <th>Amount ($)</th>
         <th>Action</th>
       </tr>
@@ -77,7 +88,7 @@
     </tbody>
     <tfoot>
       <tr>
-        <td colspan="2">Total</td>
+        <td colspan="3">Total</td>
         <td id="total">$0.00</td>
         <td></td>
       </tr>
@@ -98,6 +109,7 @@
         row.innerHTML = `
           <td>${exp.date}</td>
           <td>${exp.description}</td>
+          <td>${exp.category || ''}</td>
           <td>$${parseFloat(exp.amount).toFixed(2)}</td>
           <td><button class="remove-btn" onclick="removeExpense(${idx})">Remove</button></td>
         `;
@@ -118,9 +130,10 @@
       e.preventDefault();
       const date = document.getElementById('date').value;
       const description = document.getElementById('description').value.trim();
+      const category = document.getElementById('category').value.trim();
       const amount = document.getElementById('amount').value;
 
-      expenses.push({ date, description, amount });
+      expenses.push({ date, description, category, amount });
       localStorage.setItem('expenses', JSON.stringify(expenses));
       renderExpenses();
       form.reset();


### PR DESCRIPTION
## Summary
- replace hard-coded light colors with CSS variables to respect the dark theme
- add category inputs/columns in the static expense page and export categories in CSV
- fix total row column span and show category breakdown in charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a48fe73f9c8320aa4f07990cb8038f